### PR TITLE
Remove getPluckColumns()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1528,7 +1528,7 @@ class Builder
         return true;
     }
 
-    /**
+        /**
      * Get an array with the values of a given column.
      *
      * @param  string  $column
@@ -1537,11 +1537,10 @@ class Builder
      */
     public function pluck($column, $key = null)
     {
-        list($qualified, $unqualified) = $this->getPluckColumns($column, $key);
+        $columns = is_null($key) ? [$column] : [$column, $key];
+        $results = $this->get($columns);
 
-        $results = new Collection($this->get($qualified));
-
-        return $results->pluck($unqualified[0], Arr::get($unqualified, 1))->all();
+        return Arr::pluck($results, $this->stripTable($column), $this->stripTable($key));
     }
 
     /**
@@ -1559,21 +1558,13 @@ class Builder
     }
 
     /**
-     * Get the columns that should be used in a pluck select.
+     * Strip off the table name or alias from a column identifier
      *
-     * @param  string  $column
-     * @param  string  $key
-     * @return array
+     * @param string $column
+     * @return string
      */
-    protected function getPluckColumns($column, $key)
-    {
-        $qualified = is_null($key) ? [$column] : [$column, $key];
-
-        $unqualified = array_map(function ($column) {
-            return last(explode('.', $column));
-        }, $qualified);
-
-        return [$qualified, $unqualified];
+    protected function stripTable($column) {
+        return is_null($column) ? $column : last(explode('.', $column));
     }
 
     /**


### PR DESCRIPTION
I'm opening this here because it's just an example building on your PR to simplify the `Builder::pluck()`. I saw Taylor's comments on larachat to the effect that the combination of `pluck()` and `getPluckColumns()` is hard to follow, so I thought maybe we could just get rid of `getPluckColumns()` entirely.
1. I've replaced `getPluckColumns()` with `stripTable()`. Though calling `stripTable()` twice may seem less elegant, I think it's so dead simple it'd be hard to misunderstand.
2. I've removed the call to `Arr::get()` because it's not immediately apparent what it's doing. I took me a few seconds to realize why it was necessary. Instead, I've made `stripTable()` return `null` if the key is `null`, so no need to worry about undefined indexes.

As I said, this just an idea. Thoughts?
